### PR TITLE
Add Node 7 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ services:
 node_js:
   - "4"
   - "6"
+  - "7"


### PR DESCRIPTION
This PR adds versions 6.x and 7.x of Node to run tests on Travis.